### PR TITLE
cloud_libvirt: handle storage volume overwrite with libvirt 1.0 and newer

### DIFF
--- a/poni/cloud_libvirt.py
+++ b/poni/cloud_libvirt.py
@@ -755,7 +755,7 @@ class PoniLVPool(object):
         try:
             vol = self.pool.createXML(desc, 0)
         except libvirt.libvirtError, ex:
-            if "storage vol already exists" not in str(ex):
+            if not re.search("storage vol( '.*?')? already exists", str(ex)):
                 raise
             if not overwrite:
                 raise LVPError("%r volume already exists" % (spec["fullname"], ))


### PR DESCRIPTION
libvirt 1.0 changed the error string returned when a storage volume with
the requested name already exists; recognize both variants.
