### PR TITLE
libvirt: fix resolution of hypervisors when include or exclude are defined

### DIFF
--- a/poni/cloud_libvirt.py
+++ b/poni/cloud_libvirt.py
@@ -335,9 +335,9 @@ class LibvirtProvider(Provider):
                 # missing from the include list.
                 cands = list(conns)
                 if prop.get("hosts", {}).get("exclude"):
-                    cands = (conn for conn in cands if prop["hosts"]["exclude"] not in conn.host)
+                    cands = [conn for conn in cands if prop["hosts"]["exclude"] not in conn.host]
                 if prop.get("hosts", {}).get("include"):
-                    cands = (conn for conn in cands if prop["hosts"]["include"] in conn.host)
+                    cands = [conn for conn in cands if prop["hosts"]["include"] in conn.host]
 
                 conn = self.weighted_random_choice(cands)
                 self.log.info("cloning %r on %r", instance["vm_name"], conn.host)


### PR DESCRIPTION
before this, if include or exclude properties where present, as they were generators they would be exhausted in the function weighted_random_choice and hence that function would fail.
