### PR TITLE
aws: on-spot & more data passed to started instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ examples/db-cluster/README.html: examples/db-cluster/README.rst
 clean: deb-clean
 	rm -rf dist/ build/ poni.egg-info/ poni/*.pyc cover/ examples/puppet/README.html examples/db-cluster/README.html README.html README.txt *.pyc
 	(cd doc && make clean)
+	rm -f /tmp/poni_$(shell git describe).diff.*
+	rm -f ../poni?$(shell git describe)*
+	rm -f ../poni?$(shell git describe --abbrev=0)-*.tar.gz
 
 build-dep:
 	apt-get --yes install python-setuptools python-docutils lynx

--- a/package.mk
+++ b/package.mk
@@ -33,7 +33,7 @@ deb-clean:
 	rm -rf debian/
 
 deb: debian
-	dpkg-buildpackage -S -us -uc
+	dpkg-buildpackage -A -us -uc
 
 .PHONY: debian
 


### PR DESCRIPTION
- Security groups setting will not work on 'name' basis inside a VPC so
  now we set list of IDs for spot instances (like was done already for on-demand)
- Enabling possibility to set user_data which is visible to started instance
