### PR TITLE
cloud_aws: changes to enable deployment of on-spot instances (even with private ip address)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-dep:
 	apt-get --yes install pylint nosetests
 
 pylint:
-	python -m pylint.lint poni/*.py
+	python -m pylint.lint --disable=C0111,C0103,R0201,W0612,W0613,R0912,R0913,R0914 - --max-line-length 150 poni/*.py
 
 tests:
 	nosetests --processes=2

--- a/poni/tool.py
+++ b/poni/tool.py
@@ -859,17 +859,19 @@ class Tool:
                                 node.name))
 
                     update = updates.get(instance_id)
+
+                    self.log.info("Check node: %s (id:%s) (upd:%s)", node, instance_id, update)
                     if not update:
                         raise errors.CloudError(
-                            "cloud provider failed to return updated properties for node '{0}'".format(
-                                node.name))
+                            "cloud provider failed to return updated properties for node '{0}' (id:{1})".format(
+                                node.name, instance_id))
 
                     changes = node.log_update(update)
                     if changes:
                         change_str = ", ".join(
                             ("%s=%r (from %r)" % (c[0], c[2], c[1]))
                             for c in changes)
-                        self.log.info("%s: updated: %s", node.name, change_str)
+                        self.log.info("%s: set: %s", node.name, change_str)
                         node.save()
 
     def _get_cloud_hosts_from_args(self, arg):


### PR DESCRIPTION
I managed to deploy 7 on spot instances with this (3 ebs backed, 4 ephemeral).

Problem with ephemeral backed on-spot instances is that they take _forever_ to get them running.

The default 300 seconds AWS_TIMEOUT is not enough for that.

Let me know if there is something you wish to have changed.
