### PR TITLE
colors: use the proper ANSI sequence for 'reset'

### DIFF
--- a/poni/colors.py
+++ b/poni/colors.py
@@ -7,7 +7,7 @@ See LICENSE for details.
 """
 
 CODES = {
-    'reset': '\033[1;m',
+    'reset': '\033[0;m',
     'gray' : '\033[1;30m',
     'red' : '\033[1;31m',
     'green' : '\033[1;32m',


### PR DESCRIPTION
The more approprite 'reset' code is \33[0;m which resets all character
attributes to the terminal defaults.

See http://ascii-table.com/ansi-escape-sequences.php for details.

This change fixes the problem of poni leaving the terminal with strange
colours on exit.
